### PR TITLE
update specs

### DIFF
--- a/test/objects-test.js
+++ b/test/objects-test.js
@@ -10,7 +10,7 @@ describe('objects', () => {
     src: fs.readFileSync(path.resolve(__dirname, '..', 'objects.js'), 'utf-8')
   })
 
-  it('defines an object called `playlist`', () => {
+  it('defines an object called `playlist` containing at least one artist-song pair', () => {
     expect(typeof playlist).to.equal('object')
     expect(Object.keys(playlist).length).to.be.greaterThan(0)
   })

--- a/test/objects-test.js
+++ b/test/objects-test.js
@@ -16,9 +16,16 @@ describe('objects', () => {
   })
 
   describe('updatePlaylist(playlist, artistName, songTitle)', () => {
+    before(() => {
+      playlist['Slowdive'] = 'Alison'
+      playlist['My Bloody Valentine'] = 'Sometimes'
+    })
+
     it('adds the `artistName: songTitle` key-value pair to `playlist`', () => {
-      expect(updatePlaylist({}, 'Phil Ochs', "Here's to the State of Mississippi")).
-        to.eql({ 'Phil Ochs': "Here's to the State of Mississippi" })
+      updatePlaylist(playlist, 'Phil Ochs', "Here's to the State of Mississippi")
+
+      expect(playlist).
+        to.contain.all.keys({'Slowdive': 'Alison', 'My Bloody Valentine': 'Sometimes', 'Phil Ochs': "Here's to the State of Mississippi"})
     })
   })
 

--- a/test/objects-test.js
+++ b/test/objects-test.js
@@ -31,8 +31,13 @@ describe('objects', () => {
 
   describe('removeFromPlaylist(playlist, artistName)', () => {
     it('removes `artistName` from `playlist`', () => {
-      expect(removeFromPlaylist({ Kanye: "Gold Digger" }, "Kanye")).
-        to.eql({})
+      removeFromPlaylist(playlist, 'Slowdive')
+
+      expect(playlist).
+        to.contain.all.keys({'My Bloody Valentine': 'Sometimes', 'Phil Ochs': "Here's to the State of Mississippi"})
+
+      expect(playlist).
+        not.to.have.all.keys({'Slowdive': 'Alison'})
     })
   })
 })


### PR DESCRIPTION
As currently constructed, the spec for `updatePlaylist()` just checks that the function returns an object containing a lone artist-song pairing. It does not check whether the function actually updates the student's `playlist` object. This code passes the current test:
```js
function updatePlaylist(playlist, artistName, songTitle) {
  return Object.assign({}, {[artistName]: songTitle})
}
```
The current spec for `removeFromPlaylist()` only checks that a blank object is returned by the function. It does not test whether the provided artist-song property is actually removed from the `playlist` object. This code passes the current test:
```js
function removeFromPlaylist(playlist, artistName) {
  return {};
}
```

cc: @cernanb @aturkewi 